### PR TITLE
[自動レビュー 2026-04-29] 日次コードレビューによる自動修正

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Claude Code on the web (remote) のみで実行
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+echo "[session-start] Installing dependencies..."
+npm install
+
+echo "[session-start] Dependencies installed successfully."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Google Gemini API Key
+# Get your key at: https://aistudio.google.com/app/apikey
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Type Check & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: TypeScript type check
+        run: npx tsc
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,8 @@ import ImageUploader from './components/ImageUploader';
 import LoadingSpinner from './components/LoadingSpinner';
 import GeneratedImageDisplay from './components/GeneratedImageDisplay';
 
+const MAX_DESCRIPTION_LENGTH = 100;
+
 const App: React.FC = () => {
   const [originalImageFile, setOriginalImageFile] = useState<File | null>(null);
   const [originalImageUrl, setOriginalImageUrl] = useState<string | null>(null);
@@ -18,10 +20,10 @@ const App: React.FC = () => {
     setOriginalImageFile(file);
     setGeneratedImage(null);
     setError(null);
-    const url = URL.createObjectURL(file);
-    setOriginalImageUrl(url);
-    // Revoke previous URL to prevent memory leaks
-    return () => URL.revokeObjectURL(url);
+    setOriginalImageUrl(prev => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
   }, []);
 
   const handleGenerateClick = async () => {
@@ -51,12 +53,15 @@ const App: React.FC = () => {
   
   const handleReset = () => {
     setOriginalImageFile(null);
-    setOriginalImageUrl(null);
+    setOriginalImageUrl(prev => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
     setSubjectDescription('');
     setGeneratedImage(null);
     setError(null);
     setIsLoading(false);
-  }
+  };
 
   const isButtonDisabled = isLoading || !originalImageFile || !subjectDescription.trim();
 
@@ -82,9 +87,13 @@ const App: React.FC = () => {
                   value={subjectDescription}
                   onChange={(e) => setSubjectDescription(e.target.value)}
                   placeholder="例：赤いマントのスーパーヒーロー"
+                  maxLength={MAX_DESCRIPTION_LENGTH}
                   className="w-full px-3 py-2 bg-base-300 border border-base-300 rounded-md shadow-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-primary"
                   disabled={isLoading}
                 />
+                <p className="text-xs text-text-secondary mt-1 text-right">
+                  {subjectDescription.length} / {MAX_DESCRIPTION_LENGTH}
+                </p>
               </div>
             </div>
           </div>

--- a/components/ImageUploader.tsx
+++ b/components/ImageUploader.tsx
@@ -5,12 +5,30 @@ interface ImageUploaderProps {
   previewUrl: string | null;
 }
 
+const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
+const validateFile = (file: File): string | null => {
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    return `ファイルサイズは${MAX_FILE_SIZE_MB}MB以下にしてください（現在: ${(file.size / 1024 / 1024).toFixed(1)}MB）。`;
+  }
+  return null;
+};
+
 const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload, previewUrl }) => {
   const [isDragging, setIsDragging] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
-      onImageUpload(e.target.files[0]);
+      const file = e.target.files[0];
+      const error = validateFile(file);
+      if (error) {
+        setFileError(error);
+        return;
+      }
+      setFileError(null);
+      onImageUpload(file);
     }
   };
 
@@ -36,7 +54,14 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload, previewUrl
     e.stopPropagation();
     setIsDragging(false);
     if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      onImageUpload(e.dataTransfer.files[0]);
+      const file = e.dataTransfer.files[0];
+      const error = validateFile(file);
+      if (error) {
+        setFileError(error);
+        return;
+      }
+      setFileError(null);
+      onImageUpload(file);
     }
   }, [onImageUpload]);
 
@@ -56,11 +81,14 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload, previewUrl
           <div className="flex flex-col items-center justify-center pt-5 pb-6 text-text-secondary">
              <svg className="w-10 h-10 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path></svg>
             <p className="mb-2 text-sm"><span className="font-semibold">クリックしてアップロード</span>またはドラッグ＆ドロップ</p>
-            <p className="text-xs">PNG, JPG, または WEBP</p>
+            <p className="text-xs">PNG, JPG, または WEBP（最大{MAX_FILE_SIZE_MB}MB）</p>
           </div>
         )}
         <input id="image-upload" type="file" className="hidden" accept="image/png, image/jpeg, image/webp" onChange={handleFileChange} />
       </label>
+      {fileError && (
+        <p className="mt-2 text-sm text-red-400">{fileError}</p>
+      )}
     </div>
   );
 };

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -61,7 +61,9 @@ export const editImage = async (imageFile: File, subjectDescription: string): Pr
     return { url: imageUrl, text };
 
   } catch (error) {
-    console.error("Error editing image with Gemini API:", error);
+    if (import.meta.env.DEV) {
+      console.error("Error editing image with Gemini API:", error);
+    }
     if (error instanceof Error) {
         return Promise.reject(new Error(`画像の生成に失敗しました: ${error.message}`));
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vite/client"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig(({ mode }) => {
       },
       plugins: [react()],
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY ?? ''),
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY ?? '')
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## 概要

日次コードレビュー（2026-04-29）で発見された問題のうち、自動修正可能なものを対応しました。

## 修正内容

### セキュリティ修正
- **`.gitignore` に `.env` / `.env.*` を追加** → APIキーの誤コミットを防止 (関連: #3)
- **`.env.example` を新規追加** → 必要な環境変数を明示 (関連: #3)
- **`console.error` を開発環境のみに制限** (`import.meta.env.DEV`) → エラー詳細のブラウザ露出を防止 (関連: #4)
- **テキスト入力に `maxLength={100}` を追加** → プロンプトインジェクションの軽減 (関連: #2)

### コード品質修正
- **ファイルサイズ上限バリデーション追加（10MB）** → 過大ファイルによるAPIコスト増大・タイムアウト防止 (関連: #4)
- **`URL.createObjectURL` メモリリーク修正** → 前の画像URLを `revokeObjectURL` で解放 (関連: #4)
- **文字数カウンター表示追加** (`{n} / 100`) → UX改善

### CI / 開発環境セットアップ（新規追加）
- **`.github/workflows/ci.yml`** — Push / PR時に以下を自動実行:
  - Node.js 20 セットアップ
  - `npm install`
  - `npx tsc`（TypeScript型チェック）
  - `npm run build`（Viteビルド）
- **`.claude/hooks/session-start.sh`** — Claude Code on the web セッション開始時に `npm install` を自動実行
- **`.claude/settings.json`** — SessionStart フックを登録

## 未対応（手動対応が必要）の問題

| Issue | 内容 | 理由 |
|-------|------|------|
| #1 | APIキーのクライアントバンドル露出 | アーキテクチャ変更（サーバーサイドプロキシ導入）が必要 |
| #2 | プロンプトインジェクション（根本対策） | サーバーサイドでのバリデーション実装が必要 |
| #3 | 外部CDNのSRI未設定 | Viteビルドへの移行判断が必要 |

## テスト確認事項

- [ ] 10MB以下の画像ファイルが正常にアップロードできる
- [ ] 10MBを超えるファイルでエラーメッセージが表示される
- [ ] 文字数カウンターが正しく表示される（最大100文字）
- [ ] やり直しボタン後の再アップロードが正常に動作する
- [ ] `.env` ファイルが `git status` で追跡されないこと
- [ ] GitHub Actions CIがPR時にグリーンになること